### PR TITLE
Deprecated function

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,7 +1,10 @@
 <?php
 	
 	// Add RSS links to <head> section
-	automatic_feed_links();
+	if ( !function_exists('add_theme_support') )
+		add_theme_support( 'automatic-feed-links' );
+	else
+		automatic_feed_links();
 	
 	// Load jQuery
 	if ( !function_exists(core_mods) ) {


### PR DESCRIPTION
 automatic_feed_links is deprecated since version 3.0. Checking for add_theme_support() first and using automatic_feed_links as fallback.
