### PR TITLE
Bugfix: mobile viewport meta tag syntax

### DIFF
--- a/header.php
+++ b/header.php
@@ -76,7 +76,7 @@
 	initial-scale = 1.0 retains dimensions instead of zooming out if page height > device height
 	maximum-scale = 1.0 retains dimensions instead of zooming in if page width < device width -->
 	<!-- Uncomment to use; use thoughtfully!
-	<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0;">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 	-->
 	
 	<link rel="shortcut icon" href="<?php bloginfo('template_directory'); ?>/_/img/favicon.ico">


### PR DESCRIPTION
This commit changes the semi-colons to commas.

The usage of semi-colons caused iOS and Chrome to throw errors and not correctly apply viewport settings.
