### PR TITLE
Fix for two Notice errors in functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -8,10 +8,10 @@
             require_once($locale_file);
 	
 	// Add RSS links to <head> section
-	automatic_feed_links();
+	add_theme_support('automatic-feed-links');
 	
 	// Load jQuery
-	if ( !function_exists(core_mods) ) {
+	if ( !function_exists('core_mods') ) {
 		function core_mods() {
 			if ( !is_admin() ) {
 				wp_deregister_script('jquery');


### PR DESCRIPTION
This fixes the following two errors: 
**Notice: automatic_feed_links is deprecated since version 3.0! Use add_theme_support( 'automatic-feed-links' ) instead. Notice: Use of undefined constant core_mods - assumed 'core_mods'**
