### PR TITLE
Corrected ajax.googleapis.com url by prefixing "http:"

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -15,7 +15,7 @@
 		function core_mods() {
 			if ( !is_admin() ) {
 				wp_deregister_script('jquery');
-				wp_register_script('jquery', ("//ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"), false);
+				wp_register_script('jquery', ("http://ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"), false);
 				wp_enqueue_script('jquery');
 			}
 		}


### PR DESCRIPTION
Without the prefix, the browser attempts to load jQuery from the local server instead of from Google's CDN.
