### PR TITLE
Modify register jQuery to support protocol relative URL

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -14,8 +14,12 @@
 	if ( !function_exists(core_mods) ) {
 		function core_mods() {
 			if ( !is_admin() ) {
+                                $protocol = "http:";
+                                if ($_SERVER['HTTPS'] == 'on') {
+                                    $protocol = 'https:';
+                                }
 				wp_deregister_script('jquery');
-				wp_register_script('jquery', ("//ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"), false);
+				wp_register_script('jquery', ($protocol."//ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"), false);
 				wp_enqueue_script('jquery');
 			}
 		}


### PR DESCRIPTION
Modify jQuery to support protocol relative URL (WordPress assumes anything that starts with "//" is part of your domain-- Why WordPress, why?!!)
