### PR TITLE
Fixed datetime of posts

### DIFF
--- a/_/inc/meta.php
+++ b/_/inc/meta.php
@@ -1,5 +1,5 @@
 <footer class="meta">
-	<i>Posted on:</i> <time datetime="<?php echo date(DATE_W3C); ?>" pubdate class="updated"><?php the_time('F jS, Y') ?></time>
+	<i>Posted on:</i> <time datetime="<?php echo the_time(DATE_W3C); ?>" pubdate class="updated"><?php the_time('F jS, Y') ?></time>
 	<span class="byline author vcard">
 		<i>by</i> <span class="fn"><?php the_author() ?></span>
 	</span>


### PR DESCRIPTION
I changed the date() function in meta.php to the_time() function because it was setting the time to the _current_ datetime rather than the _post's_ datetime.
