### PR TITLE
major updates to functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -8,19 +8,28 @@
             require_once($locale_file);
 	
 	// Add RSS links to <head> section
-	automatic_feed_links();
-	
-	// Load jQuery
-	if ( !function_exists(core_mods) ) {
-		function core_mods() {
-			if ( !is_admin() ) {
-				wp_deregister_script('jquery');
-				wp_register_script('jquery', ("//ajax.googleapis.com/ajax/libs/jquery/1.6.2/jquery.min.js"), false);
-				wp_enqueue_script('jquery');
-			}
-		}
-		core_mods();
-	}
+        add_theme_support('automatic_feed_links');
+
+    // Load Scripts Modernizr & jQuery
+    function register_basic_scripts() {
+        wp_deregister_script( 'jquery' );
+        wp_register_script(
+            'modernizr',
+            ("http://ajax.aspnetcdn.com/ajax/modernizr/modernizr-2.0.6-development-only.js"),
+            '2.0.6',
+            false
+        );
+        wp_register_script(
+            'jquery',
+            ("//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"),
+            '1.8.2',
+            false
+        );
+
+        wp_enqueue_script( 'jquery' );
+        wp_enqueue_script( 'modernizr' );
+    }
+    add_action('wp_enqueue_scripts', 'register_basic_scripts');
 
 	// Clean up the <head>
 	function removeHeadLinks() {


### PR DESCRIPTION
- automatic_feed_links is deprecated since version 3.0! Use add_theme_support( 'automatic-feed-links' ) instead.
- removing core_mods and registering jQuery & Modernizr using wp_enqueue_script()
