### PR TITLE
Updating landmark roles for header and footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -5,7 +5,7 @@
  * @since HTML5 Reset 2.0
  */
 ?>
-		<footer id="footer" class="source-org vcard copyright">
+		<footer id="footer" class="source-org vcard copyright" role="contentinfo">
 			<small>&copy;<?php echo date("Y"); echo " "; bloginfo('name'); ?></small>
 		</footer>
 

--- a/header.php
+++ b/header.php
@@ -110,7 +110,7 @@
 	<div id="wrapper">
 	<!-- not needed? up to you: http://camendesign.com/code/developpeurs_sans_frontieres -->
 
-		<header id="header" role="header">
+		<header id="header" role="banner">
 			<h1><a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
 			<div class="description"><?php bloginfo( 'description' ); ?></div>
 		</header>


### PR DESCRIPTION
Updating the landmark role of 'header' to 'banner', and adding in the landmark role of 'contentinfo' to the footer. Header isn't a valid role, and figured i'd add contentinfo to the footer since we're using some landmark roles in other areas. 
